### PR TITLE
Fixed double submit on first pin creation

### DIFF
--- a/javascript/login.js
+++ b/javascript/login.js
@@ -21,6 +21,9 @@ function login() {
 
 			// Update local storage with new pin.
 			localStorage.setItem(account_number, JSON.stringify(user));
+
+			// TODO: Set up success functionality.
+			location.href="main-menu.html"
 		} else { // Pin exists for current user.
 			if (user.pin == pin_number) {
 				// TODO: Set up success functionality.


### PR DESCRIPTION
When entering the pin for the first time, the user had to click the check mark twice in order to login, this change fixes that. If the intended functionality is to have the user re-enter the pin for validation purposes, then another change is necessary.